### PR TITLE
fix: choose .ts or .js by checking TS loader.

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -6,6 +6,8 @@ import { watch } from 'chokidar'
 import * as fs from 'fs-extra'
 import * as prettier from 'prettier'
 
+const hasTsLoader = typeof require.extensions['.ts'] === 'function';
+
 export function formatCode(text: string) {
   return prettier.format(text, {
     semi: false,
@@ -16,8 +18,8 @@ export function formatCode(text: string) {
   })
 }
 
-function handleConfig(config: any, env: string) {
-  if (env !== 'prod') {
+function handleConfig(config: any, _env: string) {
+  if (hasTsLoader) {
     return config
   }
   const keys = ['entities', 'migrations', 'subscribers']
@@ -133,7 +135,7 @@ async function loadEntityAndModel(app: Application) {
 
   if (!fs.existsSync(entityDir)) return
 
-  const matching = ['unittest', 'local'].includes(app.config.env) ? '*.ts' : '*.js'
+  const matching = hasTsLoader ? '*.ts' : '*.js'
 
   const files = find(entityDir, { matching })
   app.context.repo = {}


### PR DESCRIPTION
先前用的判断加载TS文件还是JS文件的逻辑是简单地根据环境变量来进行的。
然而在实际情况中，用环境变量容易引起误判，例如: 多了一个staging的环境，这时候插件还是会默认加载ts文件，于是就有可能引起问题。
这个提交通过检查node的require是否注册了TS的加载器，来决定是加载ts文件还是js文件，这样在启动node而不是ts-node的环境中，就会直接加载js文件了。